### PR TITLE
Just some minor typos and updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,10 +57,13 @@
 
     <div class="row" style="margin-top: 15%">
       <h4 id="whats-the-official-website">What's the official website?</h4>
-        <p>That would be <a href="http://clojure.org">clojure.org</a></p>
+        <p>That would be <a href="https://clojure.org">clojure.org</a></p>
 
       <h4 id="wanna-try-clojure-before-installing">Wanna try Clojure before installing?</h4>
-      <p>Checkout the online REPL at <a href="http://www.tryclj.com/" class="uri">tryclj.com</a></p>
+      <ul>
+        <li>Checkout the online REPL at <a href="https://repl.it/languages/clojure" class="uri">repl.it</a></li>
+        <li>Or the one at <a href="http://www.tryclj.com/" class="uri">tryclj.com</a></li>
+        
 
       <h4 id="whats-the-quickest-way-to-get-started">What's the quickest way to get started?</h4>
       <p>Check if Java is installed in your system by running:
@@ -100,13 +103,13 @@
             <li><a href="https://github.com/jasongilman/proto-repl">Proto REPL</a></li>
           </ul>
         </li>
-        <li><a href="http://lighttable.com/" class="uri">LightTable</a></li>
+        <li><a href="http://lighttable.com/" class="uri">Light Table</a></li>
         <li><a href="https://sekao.net/nightcode/">Nightcode IDE</a></li>
         <li><a href="https://cursive-ide.com/">Cursive</a> (IntelliJ plugin)</li>
         <li><a href="http://doc.ccw-ide.org/">Counterclockwise</a> (Eclipse Plugin)</li>
       </ul>
       <br/>
-      <p>If you're looking for a simple, standalone solution, try LightTable.</p>
+      <p>If you're looking for a simple, standalone solution, try Light Table.</p>
 
       <h4>Wanna browse some Documentation?</h4>
       <ul>
@@ -138,7 +141,7 @@
      <!-- Section 7 -->
       <h4 id="looking-for-a-cheatsheet">Looking for a cheatsheet?</h4>
       <ul>
-        <li><a href="http://clojure.org/api/cheatsheet" class="uri">Clojure Cheatsheet</a> (the official one)</li>
+        <li><a href="https://clojure.org/api/cheatsheet" class="uri">Clojure Cheatsheet</a> (the official one)</li>
         <li><a href="https://jafingerhut.github.io/" class="uri">Clojure Cheatsheets</a></li>
       </ul>
 
@@ -154,7 +157,7 @@
       <h4 id="books">Books</h4>
       <ul>
         <li><a href="http://www.braveclojure.com/">Clojure for the Brave and True</a> (HTML version available)</li>
-        <li><a href="https://pragprog.com/book/shcloj2/programming-clojure">Programming Clojure</a></li>
+        <li><a href="https://pragprog.com/book/shcloj3/programming-clojure">Programming Clojure</a></li>
         <li><a href="http://www.clojurebook.com/">Clojure Programming</a></li>
         <li><a href="http://www.joyofclojure.com/">The Joy of Clojure</a> - Although this isn't a book for a beginner, it's too good to leave out</li>
       </ul>
@@ -215,10 +218,11 @@
         <li><a href="https://medium.com/@metabase/why-we-picked-clojure-448bf759dc83#.60g2ogfu1">Why we picked Clojure</a> - Metabase</li>
         <li><a href="https://teamgaslight.com/blog/why-were-learning-clojure">Why We're Learning Clojure</a> - Gaslight</li>
         <li><a href="https://juxt.pro/clojure-in.html">Clojure IN</a> - Case-studies on where Clojure is being used across Europe. </li>
+        <li><a href="https://clojure.org/community/community_stories">Community stories</a> - Short interviews with companies doing Clojure</li>        
       </ul>
 
       <h4>Bird's eye view of the language, it's ecosystem and community?</h4>
-      Have a look at <a href="http://blog.cognitect.com/blog/2016/1/28/state-of-clojure-2015-survey-results">State of Clojure 2015 survey results</a>
+      Have a look at <a href="http://blog.cognitect.com/blog/2017/1/31/state-of-clojure-2016-results">State of Clojure 2016 survey results</a>
     </div>
   </div>
 

--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
       <ul>
         <li>Checkout the online REPL at <a href="https://repl.it/languages/clojure" class="uri">repl.it</a></li>
         <li>Or the one at <a href="http://www.tryclj.com/" class="uri">tryclj.com</a></li>
-        
+      </ul>
 
       <h4 id="whats-the-quickest-way-to-get-started">What's the quickest way to get started?</h4>
       <p>Check if Java is installed in your system by running:


### PR DESCRIPTION
- Use https for clojure.org links
- Add repl.it Clojure repl
- Fix Light Table spelling (added space)
- 3rd ed of Programming Clojure was recently released so use that link
- Link to 2016 State of Clojure instead of 2015