### PR TITLE
Fix typo: "it's" -> "its"

### DIFF
--- a/index.html
+++ b/index.html
@@ -217,7 +217,7 @@
         <li><a href="https://juxt.pro/clojure-in.html">Clojure IN</a> - Case-studies on where Clojure is being used across Europe. </li>
       </ul>
 
-      <h4>Bird's eye view of the language, it's ecosystem and community?</h4>
+      <h4>Bird's eye view of the language, its ecosystem and community?</h4>
       Have a look at <a href="http://blog.cognitect.com/blog/2016/1/28/state-of-clojure-2015-survey-results">State of Clojure 2015 survey results</a>
     </div>
   </div>


### PR DESCRIPTION
There was another instance of the phrase "it's ecosystem." This is just a simple fix for that.